### PR TITLE
Fix typos in API Service documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - "2.7"
-- "3.2"
 - "3.3"
 - "3.4"
 - "3.5"

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ not-working responses). So in general, you'll be:
 
 ```python
 from tornado.testing import AsyncTestCase, gen_test
-from tornadomock.setup_case_helpers import ServiceCaseHelpers
+from testnado.service_case_helpers import ServiceCaseHelpers
 
 from mylib.api_client import APIClient
 
@@ -148,7 +148,7 @@ class TestAPIClient(ServiceCaseHelpers, AsyncTestCase):
         account = yield client.authenticate(my_app_token)
         # test the JSON result is used
         self.assertEqual("joeuser", account.username)
-        self.service.assert_requested(
+        service.assert_requested(
             "GET", "/v1/accounts", headers={"X-Token": my_app_token})
 ```
 


### PR DESCRIPTION
There were some typos and (maybe?) old code in the docs for the API Service helpers, so this fixes them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joshmarshall/testnado/3)
<!-- Reviewable:end -->
