### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ class TestAPIClient(ServiceCaseHelpers, AsyncTestCase):
         responder = lambda handler: handler.finish({"user": "joeuser"})
 
         service = self.add_service()
-        service.add_route("POST", "/v1/accounts", responder)
+        service.add_method("POST", "/v1/accounts", responder)
         service.listen()
 
         client = APIClient(service.url("/v1"), self.io_loop)

--- a/tests/test_service_case_helpers.py
+++ b/tests/test_service_case_helpers.py
@@ -18,7 +18,7 @@ class TestServiceTestCase(TestCaseTestCase):
         class BasicTest(ServiceCaseHelpers, AsyncTestCase):
 
             @gen_test
-            def test_add_route(self):
+            def test_add_method(self):
                 service = self.add_service()
                 service.add_method("GET", "/endpoint", handle_get)
                 self.start_services()
@@ -39,7 +39,7 @@ class TestServiceTestCase(TestCaseTestCase):
         class BasicTest(ServiceCaseHelpers, AsyncTestCase):
 
             @gen_test
-            def test_add_route(self):
+            def test_add_method(self):
                 s, port = bind_unused_port()
                 s.close()
                 service = MockService(self.io_loop, port)


### PR DESCRIPTION
One of the examples in the README refers to an `add_route` method that doesn't exist. I've corrected it to refer to `add_method`, instead.

I also fixed a couple test methods that had `add_route` in their names.