### PR TITLE
Added support for cleaning up resources

### DIFF
--- a/testnado/mock_service.py
+++ b/testnado/mock_service.py
@@ -25,6 +25,7 @@ class MockService(object):
         self.base_url = "http://" + self.host
         self.routes = {}
         self._listening = False
+        self._service = None
 
     def url(self, path):
         return urlparse.urljoin(self.base_url, path)
@@ -45,8 +46,11 @@ class MockService(object):
             handler.add_method("INFO", _unimplemented)
 
         application = Application(self.routes.items())
-        application.listen(self.port, io_loop=self.ioloop)
+        self._service = application.listen(self.port, io_loop=self.ioloop)
         self._listening = True
+
+    def stop(self):
+        self._service.stop()
 
     def add_method(self, method, route, method_handler):
         # this only works with text (not regex) routes, but it's a helper

--- a/testnado/service_case_helpers.py
+++ b/testnado/service_case_helpers.py
@@ -22,3 +22,7 @@ class ServiceCaseHelpers(object):
     def start_services(self):
         for service in self.mock_services:
             service.listen()
+
+    def stop_services(self):
+        for service in self.mock_services:
+            service.stop()

--- a/tests/test_mock_service.py
+++ b/tests/test_mock_service.py
@@ -108,3 +108,11 @@ class TestMockService(AsyncTestCase):
         response = yield self.fetch(self.service.url("/"), method="HEAD")
         self.assertEqual(200, response.code)
         self.service.assert_requested("HEAD", "/")
+
+    @gen_test
+    def test_mock_service_assert_stop_stops_the_service(self):
+        self.service.listen()
+        self.service.stop()
+
+        response = yield self.fetch(self.service.url("/"), method="HEAD")
+        self.assertEqual(599, response.code)

--- a/tests/test_service_case_helpers.py
+++ b/tests/test_service_case_helpers.py
@@ -54,3 +54,30 @@ class TestServiceTestCase(TestCaseTestCase):
                     json.loads(response.body.decode("utf-8")))
 
         self.execute_case(BasicTest)
+
+    def test_service_case_helpers_stop_services_stops_all_services(self):
+
+        def handle_get(handler):
+            handler.finish({"foo": "bar"})
+
+        class BasicTest(ServiceCaseHelpers, AsyncTestCase):
+
+            @gen_test
+            def test_stop_services(self):
+                service1 = self.add_service()
+                service2 = self.add_service()
+                service3 = self.add_service()
+                self.start_services()
+
+                self.stop_services()
+
+                client = AsyncHTTPClient(io_loop=self.io_loop)
+
+                self.assertEqual(
+                    599, (yield client.fetch(service1.url("/"), raise_error=False)).code)
+                self.assertEqual(
+                    599, (yield client.fetch(service2.url("/"), raise_error=False)).code)
+                self.assertEqual(
+                    599, (yield client.fetch(service3.url("/"), raise_error=False)).code)
+
+        self.execute_case(BasicTest)


### PR DESCRIPTION
Added `stop` method to `MockService` class and added `stop_services` method to `ServiceCaseHelpers` class.

This should help in places where we are currently running out of file descriptors after running lots of tests that create mock services.

@joshmarshall for your consideration