### PR TITLE
Fix intermittent "Address already in use" errors

### DIFF
--- a/testnado/service_case_helpers.py
+++ b/testnado/service_case_helpers.py
@@ -13,9 +13,7 @@ class ServiceCaseHelpers(object):
 
     def add_service(self, service=None):
         if not service:
-            s, port = bind_unused_port()
-            s.close()
-            service = MockService(self.io_loop, port)
+            service = MockService(self.io_loop, bind_unused_port())
         self.mock_services.append(service)
         return service
 

--- a/tests/test_mock_service.py
+++ b/tests/test_mock_service.py
@@ -116,3 +116,15 @@ class TestMockService(AsyncTestCase):
 
         response = yield self.fetch(self.service.url("/"), method="HEAD")
         self.assertEqual(599, response.code)
+
+    @gen_test
+    def test_mock_service_listen_adds_socket_when_initialized_with_tuple_port(self):
+        sock, port = bind_unused_port()
+        service = MockService(self.io_loop, (sock, port))
+        service.add_method("GET", "/", lambda x: x.finish("it worked"))
+
+        service.listen()
+
+        response = yield self.fetch(service.url("/"))
+        self.assertEqual(200, response.code)
+        self.assertEqual("it worked", response.body.decode("utf-8"))


### PR DESCRIPTION
@joshmarshall I believe this change will prevent "Address already in use" errors that happen intermittently when running tests that use Testnado. These errors were likely caused by the code:

```python
            s, port = bind_unused_port()
            s.close()
            service = MockService(self.io_loop, port)
```

Closing the socket on the second line was freeing up the port number for use by other processes running on the system and so, by the time the code called `service.listen()`, it was possible for the port to be in use.

My solution is to remove the `s.close()` call and, instead, pass the `s, port` tuple to `MockService`, which then adds the socket to the `HTTPServer` when `listen` is called.

Existing code bases that create `MockService` objects directly can continue to pass a port number, instead of a tuple, to `MockService`, thereby maintaining backward compatibility.