### PR TITLE
Make MockService port argument optional

### DIFF
--- a/testnado/mock_service.py
+++ b/testnado/mock_service.py
@@ -7,6 +7,7 @@ except ImportError:
     import urllib.parse as urlparse
 
 from tornado.httpserver import HTTPServer
+from tornado.testing import bind_unused_port
 from tornado.web import Application, HTTPError, RequestHandler
 
 
@@ -18,13 +19,15 @@ except NameError:
 
 class MockService(object):
 
-    def __init__(self, ioloop, port):
+    def __init__(self, ioloop, port=None):
         self.ioloop = ioloop
-        if isinstance(port, tuple):
+        if port is None:
+            self.socket, self.port = bind_unused_port()
+            print(self.socket, self.port)
+        elif isinstance(port, tuple):
             self.socket, self.port = port
         else:
-            self.socket = None
-            self.port = port
+            self.socket, self.port = None, port
         self.host = "localhost:{0}".format(self.port)
         self.protocol = "http"
         self.base_url = "http://" + self.host

--- a/testnado/mock_service.py
+++ b/testnado/mock_service.py
@@ -23,7 +23,6 @@ class MockService(object):
         self.ioloop = ioloop
         if port is None:
             self.socket, self.port = bind_unused_port()
-            print(self.socket, self.port)
         elif isinstance(port, tuple):
             self.socket, self.port = port
         else:

--- a/testnado/service_case_helpers.py
+++ b/testnado/service_case_helpers.py
@@ -13,7 +13,7 @@ class ServiceCaseHelpers(object):
 
     def add_service(self, service=None):
         if not service:
-            service = MockService(self.io_loop, bind_unused_port())
+            service = MockService(self.io_loop)
         self.mock_services.append(service)
         return service
 

--- a/tests/test_mock_service.py
+++ b/tests/test_mock_service.py
@@ -11,13 +11,11 @@ class TestMockService(AsyncTestCase):
 
     def setUp(self):
         super(TestMockService, self).setUp()
-        _, self.port = bind_unused_port()
-        self.service = MockService(self.io_loop, self.port)
+        self.service = MockService(self.io_loop)
 
     def test_mock_service_url_helpers(self):
-        host = "localhost:{0}".format(self.port)
+        host = "localhost:{0}".format(self.service.port)
         self.assertEqual("http", self.service.protocol)
-        self.assertEqual(self.port, self.service.port)
         self.assertEqual("http://" + host, self.service.base_url)
         self.assertEqual("http://" + host + "/foo", self.service.url("/foo"))
 
@@ -118,15 +116,23 @@ class TestMockService(AsyncTestCase):
         self.assertEqual(599, response.code)
 
     @gen_test
-    def test_mock_service_listen_adds_socket_when_initialized_without_a_port(self):
-        service = MockService(self.io_loop)
-        service.add_method("GET", "/", lambda x: x.finish("pick a port for me"))
+    def test_mock_service_listen_listens_to_specified_port_number(self):
+        sock, port = bind_unused_port()
+        sock.close()
+        service = MockService(self.io_loop, port)
+        service.add_method("GET", "/", lambda x: x.finish("use this port"))
 
         service.listen()
 
         response = yield self.fetch(service.url("/"))
         self.assertEqual(200, response.code)
-        self.assertEqual("pick a port for me", response.body.decode("utf-8"))
+        self.assertEqual("use this port", response.body.decode("utf-8"))
+
+        host = "localhost:{0}".format(port)
+        self.assertEqual("http", service.protocol)
+        self.assertEqual(port, service.port)
+        self.assertEqual("http://" + host, service.base_url)
+        self.assertEqual("http://" + host + "/foo", service.url("/foo"))
 
     @gen_test
     def test_mock_service_listen_adds_socket_when_initialized_with_tuple_port(self):
@@ -139,3 +145,9 @@ class TestMockService(AsyncTestCase):
         response = yield self.fetch("http://localhost:{0}/".format(port))
         self.assertEqual(200, response.code)
         self.assertEqual("it worked", response.body.decode("utf-8"))
+
+        host = "localhost:{0}".format(port)
+        self.assertEqual("http", service.protocol)
+        self.assertEqual(port, service.port)
+        self.assertEqual("http://" + host, service.base_url)
+        self.assertEqual("http://" + host + "/foo", service.url("/foo"))

--- a/tests/test_mock_service.py
+++ b/tests/test_mock_service.py
@@ -118,6 +118,17 @@ class TestMockService(AsyncTestCase):
         self.assertEqual(599, response.code)
 
     @gen_test
+    def test_mock_service_listen_adds_socket_when_initialized_without_a_port(self):
+        service = MockService(self.io_loop)
+        service.add_method("GET", "/", lambda x: x.finish("pick a port for me"))
+
+        service.listen()
+
+        response = yield self.fetch(service.url("/"))
+        self.assertEqual(200, response.code)
+        self.assertEqual("pick a port for me", response.body.decode("utf-8"))
+
+    @gen_test
     def test_mock_service_listen_adds_socket_when_initialized_with_tuple_port(self):
         sock, port = bind_unused_port()
         service = MockService(self.io_loop, (sock, port))
@@ -125,6 +136,6 @@ class TestMockService(AsyncTestCase):
 
         service.listen()
 
-        response = yield self.fetch(service.url("/"))
+        response = yield self.fetch("http://localhost:{0}/".format(port))
         self.assertEqual(200, response.code)
         self.assertEqual("it worked", response.body.decode("utf-8"))

--- a/tests/test_service_case_helpers.py
+++ b/tests/test_service_case_helpers.py
@@ -40,9 +40,7 @@ class TestServiceTestCase(TestCaseTestCase):
 
             @gen_test
             def test_add_method(self):
-                s, port = bind_unused_port()
-                s.close()
-                service = MockService(self.io_loop, port)
+                service = MockService(self.io_loop)
                 service.add_method("GET", "/endpoint", handle_get)
                 self.add_service(service)
                 self.start_services()


### PR DESCRIPTION
Per my post-merge commit in my previous PR, this change makes the `port` argument optional when creating a new `MockService`.

Do you want me to keep the tuple support that I added in 1.0.1? I left it in, for now, because removing it would technically break compatibility with 1.0.1, but I don't mind removing it if you don't want it there.

@joshmarshall Please review