### PR TITLE
Adding support for non-standard HTTP methods.

### DIFF
--- a/testnado/mock_service.py
+++ b/testnado/mock_service.py
@@ -120,6 +120,13 @@ class MockServiceMethods():
     @classmethod
     def add_method(cls, method, handler):
         cls.method_handlers[method.upper()] = handler
+        if method not in cls.SUPPORTED_METHODS:
+            cls.SUPPORTED_METHODS = cls.SUPPORTED_METHODS + (method,)
+
+            def _custom_method(h, *args, **kwargs):
+                return h._handle_method(method, args, kwargs)
+
+            setattr(cls, method.lower(), _custom_method)
 
     @classmethod
     def assert_requested(cls, method, path, headers):

--- a/tests/test_mock_service.py
+++ b/tests/test_mock_service.py
@@ -110,6 +110,18 @@ class TestMockService(AsyncTestCase):
         self.service.assert_requested("HEAD", "/")
 
     @gen_test
+    def test_mock_service_assert_requested_supports_nontstandard_methods(self):
+        self.service.add_method("FOOBAR", "/", lambda x: x.finish({"x": True}))
+        self.service.listen()
+
+        response = yield self.fetch(
+            self.service.url("/"), method="FOOBAR",
+            allow_nonstandard_methods=True)
+
+        self.assertEqual(200, response.code)
+        self.service.assert_requested("FOOBAR", "/")
+
+    @gen_test
     def test_mock_service_assert_stop_stops_the_service(self):
         self.service.listen()
         self.service.stop()


### PR DESCRIPTION
This is a minor change that allows support for non-standard HTTP methods at the server side, which are popular with certain API services, etc. (For instance, PURGE requests from Fastly.)

@tjensen @spiralman For consideration.