### PR TITLE
Making `stop` method do nothing when not started

### DIFF
--- a/testnado/mock_service.py
+++ b/testnado/mock_service.py
@@ -61,7 +61,8 @@ class MockService(object):
         self._listening = True
 
     def stop(self):
-        self._service.stop()
+        if self._service is not None:
+            self._service.stop()
 
     def add_method(self, method, route, method_handler):
         # this only works with text (not regex) routes, but it's a helper

--- a/tests/test_mock_service.py
+++ b/tests/test_mock_service.py
@@ -127,6 +127,11 @@ class TestMockService(AsyncTestCase, ServiceTestHelpers):
 
         yield self.assert_closed(self.service.url("/"), method="HEAD")
 
+    def test_mock_service_stop_does_nothing_when_it_has_not_been_started_yet(self):
+        self.service.stop()
+
+        self.assertTrue(True, "Stop should not raise")
+
     @gen_test
     def test_mock_service_listen_listens_to_specified_port_number(self):
         sock, port = bind_unused_port()


### PR DESCRIPTION
@joshmarshall For your consideration

I ran into an issue where I had a test class that was trying to clean things up properly after every test, but it was giving errors for cases that didn't start any mock services:

```python
class TestExample(ServiceCaseHelpers, AsyncHTTPTestCase):
    def setUp(self):
        super().setUp()
        self.mock_service = self.add_service()

    def tearDown(self):
        self.stop_services()  # <-- this fails if self.mock_service hasn't been started
        super().tearDown()
```

This change prevents `self.stop_services` from generating errors when one or more mock services haven't been started by making the `MockService` `stop` method do nothing when it hasn't been stated.